### PR TITLE
feat: 메시지 템플릿 개선 및 PR 브랜치 정보 추가

### DIFF
--- a/src/formatters/formatter/pullRequestFormatter.ts
+++ b/src/formatters/formatter/pullRequestFormatter.ts
@@ -11,13 +11,22 @@ export interface PullRequestMessageData {
   headBranch: string;
 }
 
+const ALLOWED_ACTIONS = [
+  "opened", // PR이 처음 생성되었을 때
+  "closed", // PR이 닫혔을 때 (병합되었거나 수동으로 닫힌 경우 포함)
+  "synchronize", // PR의 소스 브랜치(head)에 새로운 커밋이 push되었을 때
+  "ready_for_review", // draft 상태의 PR이 리뷰 가능한 상태로 전환되었을 때
+  "review_requested", // 특정 사용자에게 리뷰를 요청했을 때
+  "edited", // PR의 제목, 설명 등이 수정되었을 때
+];
+
 export const pullRequestFormatter: BaseFormatter<PullRequestMessageData> = {
   canHandle(payload) {
-    return payload.pull_request && payload.action;
+    return payload.pull_request && ALLOWED_ACTIONS.includes(payload.action);
   },
 
   format(payload) {
-    const { number, pull_request } = payload;
+    const { number, pull_request, action } = payload;
 
     const result: MessageFormatResult<PullRequestMessageData> = {
       type: "PULL_REQUEST",
@@ -26,7 +35,7 @@ export const pullRequestFormatter: BaseFormatter<PullRequestMessageData> = {
         prTitle: pull_request.title,
         author: pull_request.user?.login,
         url: pull_request.html_url,
-        action: payload.action.toUpperCase(),
+        action: action,
         baseBranch: pull_request.base.ref,
         headBranch: pull_request.head.ref,
       },

--- a/src/formatters/formatter/pullRequestFormatter.ts
+++ b/src/formatters/formatter/pullRequestFormatter.ts
@@ -7,6 +7,8 @@ export interface PullRequestMessageData {
   author: string;
   url: string;
   action: string;
+  baseBranch: string;
+  headBranch: string;
 }
 
 export const pullRequestFormatter: BaseFormatter<PullRequestMessageData> = {
@@ -25,6 +27,8 @@ export const pullRequestFormatter: BaseFormatter<PullRequestMessageData> = {
         author: pull_request.user?.login,
         url: pull_request.html_url,
         action: payload.action.toUpperCase(),
+        baseBranch: pull_request.base.ref,
+        headBranch: pull_request.head.ref,
       },
     };
 

--- a/src/formatters/formatter/pullRequestReviewFormatter.ts
+++ b/src/formatters/formatter/pullRequestReviewFormatter.ts
@@ -6,6 +6,8 @@ export interface PullRequestReviewMessageData {
   prNumber: number; // PR 번호
   prTitle: string; // PR 제목
   url: string; // 리뷰 링크
+  approved: boolean; // 리뷰 승인 여부
+  comment: string | null; // 리뷰 코멘트 내용
 }
 
 export const pullRequestReviewFormatter: BaseFormatter<PullRequestReviewMessageData> =
@@ -27,6 +29,8 @@ export const pullRequestReviewFormatter: BaseFormatter<PullRequestReviewMessageD
           prNumber: pull_request.number,
           prTitle: pull_request.title,
           url: review.html_url,
+          approved: review.state === "approved",
+          comment: review.body || null,
         },
       };
 

--- a/src/formatters/formatter/pushFormatter.ts
+++ b/src/formatters/formatter/pushFormatter.ts
@@ -4,6 +4,7 @@ import { BaseFormatter } from "./baseFormatter";
 export interface PushMessageData {
   author: string;
   commits: { message: string; url: string }[];
+  ref: string;
 }
 
 export const pushFormatter: BaseFormatter<PushMessageData> = {
@@ -12,7 +13,7 @@ export const pushFormatter: BaseFormatter<PushMessageData> = {
   },
 
   format(payload) {
-    const { pusher, commits } = payload;
+    const { pusher, commits, ref } = payload;
     const arrayCommits = commits.map((c: any) => ({
       message: c.message,
     }));
@@ -22,6 +23,7 @@ export const pushFormatter: BaseFormatter<PushMessageData> = {
       data: {
         author: pusher.name,
         commits: arrayCommits,
+        ref: ref,
       },
     };
 

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -5,8 +5,9 @@ import { pullRequestFormatter } from "./formatter/pullRequestFormatter";
 import { commentFormatter } from "./formatter/commentFormatter";
 import { MessageFormatResult } from "./types/messageTypes";
 
+// 메시지를 보내기 위한 포맷터들을 배열로 정의합니다.
 const formatters: BaseFormatter[] = [
-  pushFormatter,
+  // pushFormatter,
   issueFormatter,
   pullRequestFormatter,
   commentFormatter,

--- a/src/formatters/templates/messageTemplates.ts
+++ b/src/formatters/templates/messageTemplates.ts
@@ -57,7 +57,7 @@ export function generateMessage(
 
       lines = [
         `*\\[📌 이슈 ${escapedAction}\\]* ${escapedAuthor}`,
-        `📌 *ISSUE 번호:* #${issueNumber}`,
+        `📌 *ISSUE 번호:* \\#${issueNumber}`,
         `📝 *제목:* ${escapedTitle}`,
         `🔗 ${escapedUrl}`,
       ];
@@ -77,7 +77,7 @@ export function generateMessage(
 
       lines = [
         `*\\[🔀 PR ${escapedAction}\\]* ${escapedAuthor}`,
-        `📌 *PR 번호:* #${prNumber}`,
+        `📌 *PR 번호:* \\#${prNumber}`,
         `📝 *제목:* ${escapedTitle}`,
         `🌿 *브랜치:* \`${escapedHeadBranch}\` → \`${escapedBaseBranch}\``,
         `🔗 ${escapedUrl}`,
@@ -114,7 +114,7 @@ export function generateMessage(
 
       lines = [
         `*\\[✅ PR ${statusText}\\]* ${escapedReviewer}`,
-        `📌 *PR 번호:* #${prNumber}`,
+        `📌 *PR 번호:* \\#${prNumber}`,
         `📝 *제목:* ${escapedTitle}`,
       ];
 

--- a/src/formatters/templates/messageTemplates.ts
+++ b/src/formatters/templates/messageTemplates.ts
@@ -30,51 +30,70 @@ export function generateMessage(
 
   switch (result.type) {
     case "PUSH": {
-      const { author, commits } = result.data;
+      const { author, commits, ref } = result.data;
+
       const resolvedPusher = escapeMarkdownV2(resolveUsername(author));
-      const commitLines = commits.map(
-        (c: any) => `\\- ${escapeMarkdownV2(c.message)}`
-      );
+      const branchName = ref.replace("refs/heads/", "");
+      const escapedBranchName = escapeMarkdownV2(branchName);
+      const commitLines = commits
+        .map((c: any) => `\\- ${escapeMarkdownV2(c.message)}`)
+        .join("\n");
+
       lines = [
         `*\\[🚀 Git Push\\]* ${resolvedPusher}`,
-        `📝 *커밋 내역*\n${commitLines.join("\n")}`,
+        `🌿 *브랜치:* \`${escapedBranchName}\``,
+        `📝 *커밋 내역*\n${commitLines}`,
       ];
       break;
     }
 
     case "ISSUE": {
       const { title, action, url, author, issueNumber } = result.data;
+
+      const escapedAction = escapeMarkdownV2(action);
+      const escapedAuthor = escapeMarkdownV2(resolveUsername(author));
+      const escapedTitle = escapeMarkdownV2(title);
+      const escapedUrl = escapeMarkdownV2(url);
+
       lines = [
-        `*\\[📌 이슈 ${escapeMarkdownV2(action)}\\]* ${escapeMarkdownV2(
-          resolveUsername(author)
-        )}`,
+        `*\\[📌 이슈 ${escapedAction}\\]* ${escapedAuthor}`,
         `📌 *ISSUE 번호:* #${issueNumber}`,
-        `📝 *제목:* ${escapeMarkdownV2(title)}`,
-        `🔗 ${escapeMarkdownV2(url)}`,
+        `📝 *제목:* ${escapedTitle}`,
+        `🔗 ${escapedUrl}`,
       ];
       break;
     }
 
     case "PULL_REQUEST": {
       const { prNumber, prTitle, action, author, url } = result.data;
+
+      const escapedAction = escapeMarkdownV2(action);
+      const escapedAuthor = escapeMarkdownV2(resolveUsername(author));
+      const escapedTitle = escapeMarkdownV2(prTitle);
+      const escapedUrl = escapeMarkdownV2(url);
+
       lines = [
-        `*\\[🔀 PR ${escapeMarkdownV2(action)}\\]* ${escapeMarkdownV2(
-          resolveUsername(author)
-        )}`,
+        `*\\[🔀 PR ${escapedAction}\\]* ${escapedAuthor}`,
         `📌 *PR 번호:* #${prNumber}`,
-        `📝 *제목:* ${escapeMarkdownV2(prTitle)}`,
-        `🔗 ${escapeMarkdownV2(url)}`,
+        `📝 *제목:* ${escapedTitle}`,
+        `🔗 ${escapedUrl}`,
       ];
       break;
     }
 
     case "COMMENT": {
       const { comment, issueTitle, url, author } = result.data;
+
+      const escapedAuthor = escapeMarkdownV2(resolveUsername(author));
+      const escapedTitle = escapeMarkdownV2(issueTitle);
+      const escapedComment = escapeMarkdownV2(comment);
+      const escapedUrl = escapeMarkdownV2(url);
+
       lines = [
-        `*\\[💬 이슈 코멘트\\]* ${escapeMarkdownV2(resolveUsername(author))}`,
-        `🧵 *이슈 제목:* ${escapeMarkdownV2(issueTitle)}`,
-        `🗨️ *코멘트 내용:*\n"${escapeMarkdownV2(comment)}"`,
-        `🔗 ${escapeMarkdownV2(url)}`,
+        `*\\[💬 이슈 코멘트\\]* ${escapedAuthor}`,
+        `🧵 *이슈 제목:* ${escapedTitle}`,
+        `🗨️ *코멘트 내용:*\n"${escapedComment}"`,
+        `🔗 ${escapedUrl}`,
       ];
       break;
     }
@@ -82,30 +101,32 @@ export function generateMessage(
     case "PULL_REQUEST_REVIEW": {
       const { reviewer, prNumber, prTitle, url, approved, comment } =
         result.data;
+
+      const escapedReviewer = escapeMarkdownV2(resolveUsername(reviewer));
+      const escapedTitle = escapeMarkdownV2(prTitle);
+      const escapedComment = comment ? escapeMarkdownV2(comment) : null;
+      const escapedUrl = escapeMarkdownV2(url);
+      const statusText = approved ? "Approved!" : "리뷰 제출됨";
+
       lines = [
-        `*\\[✅ PR ${
-          approved ? "Approved!" : "리뷰 제출됨"
-        }\\]* ${escapeMarkdownV2(resolveUsername(reviewer))}`,
+        `*\\[✅ PR ${statusText}\\]* ${escapedReviewer}`,
         `📌 *PR 번호:* #${prNumber}`,
-        `📝 *제목:* ${escapeMarkdownV2(prTitle)}`,
+        `📝 *제목:* ${escapedTitle}`,
       ];
 
-      if (comment) {
+      if (escapedComment) {
         lines.push(`💬 *리뷰 코멘트*`);
-        lines.push(`${escapeMarkdownV2(comment)}`);
+        lines.push(escapedComment);
       }
 
-      lines.push(`🔗 ${escapeMarkdownV2(url)}`);
-
+      lines.push(`🔗 ${escapedUrl}`);
       break;
     }
 
     default:
-      lines = [
-        `⚠️ *알 수 없는 이벤트 타입입니다:* \`${escapeMarkdownV2(
-          result.type
-        )}\``,
-      ];
+      const escapedType = escapeMarkdownV2(result.type);
+
+      lines = [`⚠️ *알 수 없는 이벤트 타입입니다:* \`${escapedType}\``];
   }
 
   return lines.join("\n");

--- a/src/formatters/templates/messageTemplates.ts
+++ b/src/formatters/templates/messageTemplates.ts
@@ -17,8 +17,8 @@ export function escapeMarkdownV2(text: string): string {
   return text.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, "\\$1");
 }
 
-function escapeMarkdownV2Lines(lines: string[]): string {
-  return lines.map((line) => escapeMarkdownV2(line)).join("\n");
+function capitalizeFirst(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 export function generateMessage(
@@ -68,7 +68,7 @@ export function generateMessage(
       const { prNumber, prTitle, action, author, url, baseBranch, headBranch } =
         result.data;
 
-      const escapedAction = escapeMarkdownV2(action);
+      const escapedAction = escapeMarkdownV2(capitalizeFirst(action));
       const escapedAuthor = escapeMarkdownV2(resolveUsername(author));
       const escapedTitle = escapeMarkdownV2(prTitle);
       const escapedUrl = escapeMarkdownV2(url);

--- a/src/formatters/templates/messageTemplates.ts
+++ b/src/formatters/templates/messageTemplates.ts
@@ -65,17 +65,21 @@ export function generateMessage(
     }
 
     case "PULL_REQUEST": {
-      const { prNumber, prTitle, action, author, url } = result.data;
+      const { prNumber, prTitle, action, author, url, baseBranch, headBranch } =
+        result.data;
 
       const escapedAction = escapeMarkdownV2(action);
       const escapedAuthor = escapeMarkdownV2(resolveUsername(author));
       const escapedTitle = escapeMarkdownV2(prTitle);
       const escapedUrl = escapeMarkdownV2(url);
+      const escapedHeadBranch = escapeMarkdownV2(headBranch);
+      const escapedBaseBranch = escapeMarkdownV2(baseBranch);
 
       lines = [
         `*\\[🔀 PR ${escapedAction}\\]* ${escapedAuthor}`,
         `📌 *PR 번호:* #${prNumber}`,
         `📝 *제목:* ${escapedTitle}`,
+        `🌿 *브랜치:* \`${escapedHeadBranch}\` → \`${escapedBaseBranch}\``,
         `🔗 ${escapedUrl}`,
       ];
       break;

--- a/src/formatters/templates/messageTemplates.ts
+++ b/src/formatters/templates/messageTemplates.ts
@@ -80,15 +80,23 @@ export function generateMessage(
     }
 
     case "PULL_REQUEST_REVIEW": {
-      const { reviewer, prNumber, prTitle, url } = result.data;
+      const { reviewer, prNumber, prTitle, url, approved, comment } =
+        result.data;
       lines = [
-        `*\\[✅ PR 리뷰 제출됨\\]* ${escapeMarkdownV2(
-          resolveUsername(reviewer)
-        )}`,
+        `*\\[✅ PR ${
+          approved ? "Approved!" : "리뷰 제출됨"
+        }\\]* ${escapeMarkdownV2(resolveUsername(reviewer))}`,
         `📌 *PR 번호:* #${prNumber}`,
         `📝 *제목:* ${escapeMarkdownV2(prTitle)}`,
-        `🔗 ${escapeMarkdownV2(url)}`,
       ];
+
+      if (comment) {
+        lines.push(`💬 *리뷰 코멘트*`);
+        lines.push(`${escapeMarkdownV2(comment)}`);
+      }
+
+      lines.push(`🔗 ${escapeMarkdownV2(url)}`);
+
       break;
     }
 


### PR DESCRIPTION
## 변경 내용
- PR 리뷰 알림 메시지에 Approved 여부 반영
- PUSH 메시지에 브랜치 이름 포함
- PR 메시지에 소스 브랜치 → 대상 브랜치 정보 추가
- 중복된 escape 및 resolve 처리 로직을 const로 추상화하여 템플릿 구조 개선

## 목적
- GitHub 이벤트 메시지의 가독성과 정보 전달력을 향상
- 유지보수성을 높이기 위한 메시지 템플릿 리팩토링

